### PR TITLE
Fix trailing line for package.el compatibility

### DIFF
--- a/ox-twiki.el
+++ b/ox-twiki.el
@@ -328,4 +328,4 @@ You can set the following options inside of the document:
 
 (provide 'ox-twiki)
 
-;; ox-twiki.el ends here
+;;; ox-twiki.el ends here


### PR DESCRIPTION
The parsing logic in package.el requires all the semicolons...

(In connection with https://github.com/milkypostman/melpa/pull/1192)

-Steve
